### PR TITLE
Allow nested Bootstrap grids

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -478,7 +478,12 @@ var Col = React.createClass({
 
   render() {
     return <div className={this.getColClassName()}>
-      {this.props.children}
+      {React.Children.map(this.props.children, (child, index) => {
+        return React.cloneElement(child, {
+          form: this.props.form
+        , spinner: this.props.spinner
+        })
+      })}
     </div>
   }
 })

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -479,10 +479,14 @@ var Col = React.createClass({
   render() {
     return <div className={this.getColClassName()}>
       {React.Children.map(this.props.children, (child, index) => {
-        return React.cloneElement(child, {
-          form: this.props.form
-        , spinner: this.props.spinner
-        })
+        if (child.type === Row) {
+          return React.cloneElement(child, {
+            form: this.props.form
+          , spinner: this.props.spinner
+          })
+        } else {
+          return child
+        }
       })}
     </div>
   }


### PR DESCRIPTION
Bootstrap allows [grid nesting](http://getbootstrap.com/css/#grid-nesting), but right now it is not possible to have `Row`s as `Col`'s children because `Col` does not pass down the `form` prop.

This simple change fixes that.
