### PR TITLE
Fixed an error was being raised as pointed at #12 even if one follow …

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -184,6 +184,7 @@ var BootstrapForm = React.createClass({
   },
 
   propTypes: {
+    form: React.PropTypes.instanceOf(Form),
     spinner: React.PropTypes.string
   },
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -184,7 +184,6 @@ var BootstrapForm = React.createClass({
   },
 
   propTypes: {
-    form: React.PropTypes.instanceOf(Form).isRequired,
     spinner: React.PropTypes.string
   },
 
@@ -194,11 +193,17 @@ var BootstrapForm = React.createClass({
     }
   },
 
-  render() {
-    patchForm(this.props.form)
-    return <div>
-      {this.renderRows()}
-    </div>
+  render:function() {
+    if (this.props.form === undefined) {
+      console.error("Warning newforms-bootstrap requires to be passed between newforms.Form tags.");
+      return React.createElement("div", null, null);
+    }
+    else {
+      patchForm(this.props.form)
+      return React.createElement("div", null, 
+        this.renderRows()
+      )
+    }
   },
 
   renderRows() {


### PR DESCRIPTION
Fixed an error was being raised as pointed at #12 even if one follow the docs the docs:

```
Warning: Failed propType: Required prop `form` was not specified in `BootstrapForm`. Check the render method of `App`.
```

As far as I see the `required` of form is only used in order to guarantee it is used between a newforms.Form tag. But if you don`t pass it, an error is raised anyway:

```
Uncaught TypeError: Cannot read property `__patchedByBootstrapForm` of undefined
```

So I removed the mandatory form and made a validation inside render.

Feel free to refuse this fix since I`m not sure whether making form required has an important need that I was unaware of.
